### PR TITLE
Standardised footer

### DIFF
--- a/src/app/components/site-footer/site-footer.component.html
+++ b/src/app/components/site-footer/site-footer.component.html
@@ -5,13 +5,12 @@
         <div class="col-sm-12">
           <ul class="list-inline">
             <li class="list-inline-item"><a target="_blank" href="https://www.dta.gov.au/privacy-statement/">Privacy</a></li>
-            <li class="list-inline-item"><a [routerLink]="['/'+routePath.CONTACT]">Need Help</a></li>
+            <li class="list-inline-item"><a href="mailto:secure.cloud@digital.gov.au">Need Help?</a></li>
             <li class="list-inline-item"><a target="_blank" href="https://www.dta.gov.au/accessibility/">Accessibility</a></li>
             <li class="list-inline-item"><a target="_blank" href="https://www.dta.gov.au/disclaimer/">Disclaimer</a></li>
           </ul>
           <div style="clear:both">
             <p><img class="au-responsive-media-img footer-img" src="/assets/img/header-logo-agov.png" alt="Brand image "></p>
-            <p>Have a question about the CAT? Contact DTA: <a href="mailto:secure.cloud@digital.gov.au">secure.cloud@digital.gov.au</a></p>
             <p><small>&copy; Commonwealth of Australia. With the exception of the Commonwealth Coat of Arms</small></p>
             <p><small>and where otherwise noted, this work is licensed under the
               <a href="https://github.com/govau/uikit/blob/master/LICENSE" rel="external">MIT Licence</a></small></p>


### PR DESCRIPTION
Make footer look more like designsystem.gov.au/cloud.gov.au.
Include Licence exception to Coat of Arms.
Replace Need Help? link with mailto:.