### PR TITLE
 Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: sudo apt-get install cf-cli
       - run: cf install-plugin https://github.com/govau/autopilot/releases/download/0.0.5-venapp/autopilot-linux -f
       - run: cf version                # log what version we are running
-      - run: cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USER -p $CF_PASSWORD
+      - run: cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
       - run: cd dist && cf zero-downtime-push assess -f manifest-staging.yml
 
   # DEPLOY-PRODUCTION JOB
@@ -56,7 +56,7 @@ jobs:
       - run: sudo apt-get install cf-cli
       - run: cf install-plugin https://github.com/govau/autopilot/releases/download/0.0.5-venapp/autopilot-linux -f
       - run: cf version
-      - run: cf login -a $CF_API_PROD -o $CF_ORG_PROD -s $CF_SPACE_PROD -u $CF_USER_PROD -p $CF_PASSWORD_PROD
+      - run: cf login -a $CF_API_PROD -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_PROD
       - run: cd dist && cf zero-downtime-push assess -f manifest.yml
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cloud Assessment Tool
 
+[![CircleCI](https://circleci.com/gh/govau/cloud-assessment.svg?style=svg)](https://circleci.com/gh/govau/cloud-assessment)
+
 ## Outline
 
 The [Cloud Assessment Tool (CAT)](https://assess.cloud.gov.au) is designed to help Australian Government agencies discover and understand their compliance obligations when moving to cloud. It is part of the [Digital Transformation Agency's](https://www.dta.gov.au) [Secure Cloud Strategy](https://www.dta.gov.au/our-projects/secure-cloud-strategy).


### PR DESCRIPTION
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to
make it easier for us we need to have a standard naming convention for environment
variables across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use
the standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that arent
in the above list. EDIT - I have gone ahead and removed old CF_* env vars in circleci since they will already have stopped working
